### PR TITLE
Update 3.1.0

### DIFF
--- a/PSLM.psd1
+++ b/PSLM.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PSLM.psm1'
 
 # Version number of this module.
-ModuleVersion = '3.0'
+ModuleVersion = '3.1.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -110,7 +110,7 @@ PrivateData = @{
         # ReleaseNotes = ''
 
         # Prerelease string of this module
-        Prerelease = 'dev3'
+        #Prerelease = ''
 
         # Flag to indicate whether the module requires explicit user acceptance for install/update/save
         # RequireLicenseAcceptance = $false

--- a/PSLM.psm1
+++ b/PSLM.psm1
@@ -40,7 +40,6 @@ class PSLM #PowerShell Logging Module
 		[string] $logType,
         [bool] $PrintToConsole,
 		[string] $TimestampFormat
-
     )
 	{
 
@@ -77,8 +76,10 @@ class PSLM #PowerShell Logging Module
 			$this.LogFilePath = $logFilePath
 		}
         
+		$this.LogFilePath = $logFilePath
+
 		#Check if path has backslash or slash at the end
-		if(-not($this.LogFilePath[$this.LogFilePath-1] -eq "/") -or ($this.LogFilePath[$this.LogFilePath-1] -eq "\")) 
+		if(-not($this.LogFilePath[$this.LogFilePath.Length-1] -eq "/") -or ($this.LogFilePath[$this.LogFilePath.Length-1] -eq "\")) 
 		{
 			# Append '\'
 			$this.LogFilePath = $this.LogFilePath+"\"
@@ -87,7 +88,7 @@ class PSLM #PowerShell Logging Module
 
 		# Set full log path
 		$this.LogFileFullPath = $this.LogFilePath+$this.LogFileName
-		Write-Host "Path:" $this.LogFilePath "  Name:" $this.LogFileName
+		#DEBUG#Write-Host "Path:" $this.LogFilePath "  Name:" $this.LogFileName
 
 
 		# Set LogDate
@@ -142,16 +143,20 @@ class PSLM #PowerShell Logging Module
 
 	# Change log file path
     [void] SetLogFilePath($FilePath) {
+		$FilePath = Resolve-Path $FilePath
+		$this.Entry("d","SetLogFilePath: $FilePath")
         $this.logFilePath = $FilePath
     }
 
 	# Change time stamp format
     [void] SetTimeFormat($Format) {
+		$this.Entry("d","SetTimeFormat: $Format")
         $this.TimestampFormat = $Format
     }
 
 	# Enable / Disable console output
     [void] SetConsoleOut($BOOL) {
+		$this.Entry("d","SetConsoleOut: $BOOL")
         $this.PrintToConsole = $BOOL
     }
 

--- a/PSLM.psm1
+++ b/PSLM.psm1
@@ -225,7 +225,7 @@ class PSLM #PowerShell Logging Module
         else {
             $messageType = $Type
         }
-		return $Type
+		return $messageType
 	}
 
 

--- a/PSLM.psm1
+++ b/PSLM.psm1
@@ -1,5 +1,5 @@
 ### PowerShell Logging Module
-# 02.11.2023 - v3.1.0
+# 06.11.2023 - v3.1.0
 
 ### USAGE
 #Import Module:		Using module ".\PSLM.psd1" (Must be the first line!)
@@ -23,7 +23,7 @@ class PSLM #PowerShell Logging Module
 	[string] $ModulePath		#
     [bool] 	 $PrintToConsole	#Should entries be printed out to console
 	[string] $logColor			#Color used for entries
-	[string] $TimestampFormat 	#Format of the timestamp | default values: 
+	[string] $TimestampFormat 	#Format of the timestamp
 
 	#LogTypeGroups
 	$LTDefault
@@ -75,7 +75,7 @@ class PSLM #PowerShell Logging Module
 		} else {
 			$this.LogFilePath = $logFilePath
 		}
-        
+
 		$this.LogFilePath = $logFilePath
 
 		#Check if path has backslash or slash at the end
@@ -109,7 +109,7 @@ class PSLM #PowerShell Logging Module
         }else{
 			$this.LogType = $this.EvalLogType($logType)
 		}
-		
+
 		#Get timestamp format
 		if($null -ne $TimestampFormat) 
 		{
@@ -131,14 +131,14 @@ class PSLM #PowerShell Logging Module
 		} else {
 			$this.TimestampFormat = "dd-MM-yyyy-HH:mm:ss.ffff"
 		}
-		
-		
+
+
 		#LogTypeGroups
 		$this.LTDefault 	= "ERROR","INFO","WARNING","CRITICAL"
 		$this.LTDebug 		= "ERROR","INFO","WARNING","CRITICAL","DEBUG"
 		$this.LTProductive  = "ERROR","INFO","CRITICAL"
 		$this.LTError 		= "ERROR"
-		$this.LTCritical 	= "CRITICAL"	
+		$this.LTCritical 	= "CRITICAL"
     }
 
 	# Change log file path

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PowerShell Logging Module - Version 3.0.1
+# PowerShell Logging Module - Version 3.1.0
  Logging Module made for Powershell
  
 <br>

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 <br>
 
 ## Logentry types (case insensitive) 
- - INFO 	(info, inf, i)
+ - INFO 	  (info, inf, i)
  - WARNING  (warning, warn, w)
  - CRITICAL (critical, crit, c)
- - ERROR	(error, err, e)
+ - ERROR	  (error, err, e)
  - DEBUG    (debug, dbg, d)
  - Custom   (Just enter any string you wish)
 
@@ -37,11 +37,10 @@
 ### Attributes
 
 > LOGNAME:  **"%yyyy%-%MM%-%dd%-log.txt"** <br>
-> Use: <br> ``%dd%`` : Day, ``%MM%`` : months, ``%yyyy%`` : year, ``%hh%`` : hour,``%mm%`` : minutes, ``%ss%`` : seconds <br>
+> Use: <br> ``%dd%`` : Day, ``%MM%`` : months, ``%yyyy%`` : year, ``%hh%`` : hour,``%m%`` : minutes, ``%ss%`` : seconds <br>
 > They will be replaced with the acording value e.g. %yyyy% = 2023
 
 > LOGPATH: **".\logs\"** or **"C:\the\path\"** <br>
-> Important: A backslash **must** be placed at the end of the path.
 
 > LOGMODE: **"Default"** <br>
 > Choose one of the logmodes listed above.
@@ -66,12 +65,12 @@
 <br>
 
 >### Entry(TYPE,MESSAGE)
->Creates a single log entry.
+>Creates a single log entry with timestamp.
 
 <br>
 
 >### SetLogFilePath(PATH)
->Set the path to the log file.
+>Set/change the path to the log file.
 
 <br>
 
@@ -81,12 +80,13 @@
 <br>
 
 >### SetTimeFormat(STRING)
->Set a customized timeformat.
+>Set/change the timeformat to a customized format.
 
 <br>
 
 >### LogCleanup(int:RETENTIONDAYS)
->Clean logs that are older than the retention date specified in the constructor.
+>Clean logs that are older than the retention date specified in the constructor. <br>
+>Warning: This function deletes **all** files inside the logfoler, that are older than the retentiondays! This also effects non log files, because the tool has no feature to detect if the file is a log file or something else! 
 
 <br>
 
@@ -96,6 +96,13 @@ _________________
 <br>
 
 # Changelog
+
+## Version 3.1.0
+- Feature: Info bracket colored in darkcyan
+- Feature: Add backslash to end of log path, if not already set by user
+- Change: Example file import .psd1 instead od .psm1
+- Fix: Timestamp change from minutes from %mm% to %m%
+- Fix: Unable to change timestamp format in constructor
 
 ## Version 3.0.1
  - INFO color changed to dark cyan

--- a/example.ps1
+++ b/example.ps1
@@ -19,7 +19,7 @@ $Log.Entry("crit", "Critical Test Message")
 $Log.Entry("Error", "Error Test Message")
 
 #Log Cleanup function | Arguments: RetentionDays[INT] (maximum age in days)
-$Log.LogCleanup(14)
+$Log.LogCleanup(9999)
 
 
 pause

--- a/example.ps1
+++ b/example.ps1
@@ -4,11 +4,11 @@
 #>
 
 #Import PSLM like this:
-Using module .\PSLM.psm1
+Using module .\PSLM.psd1
 
 #Arguments: LogName[STRING], LogPath[STRING], LogMode[STRING], PrintToConsole[BOOL], [string] $TimestampFormat, RetentionDays[INT]
 #LogPath: when using relative paths use  .\[DIRNAME]\  else you'll get errors.
-$Log = New-Object -TypeName PSLM -ArgumentList ("log-%hh%-%mm%-%ss%.txt",".\logs\","DEBUG",$TRUE,"default")
+$Log = New-Object -TypeName PSLM -ArgumentList ("TEST-log-%hh%-%mm%-%ss%.txt", ".\", "DEBUG", $TRUE, "default")
 
 $Log.Entry("Info", "Logging Mode: "+$Log.LogTypes)
 $Log.Entry("Info", "Info Test Message")
@@ -19,7 +19,7 @@ $Log.Entry("crit", "Critical Test Message")
 $Log.Entry("Error", "Error Test Message")
 
 #Log Cleanup function | Arguments: RetentionDays[INT] (maximum age in days)
-$Log.LogCleanup(1)
+$Log.LogCleanup(14)
 
 
 pause


### PR DESCRIPTION
### Features
- Append '\' at the end of the logfilepath if missing
- New function SelectEntryType, evaluates the type of entry (moved out of Entry() function)
- Added some comments to main file
- Debug Logs added to SetLogFilePath, SetTimeFormat, SetConsoleOut

### Changes
- Rewokred usage guide in pslm.psm1
- Logfilename variables: changed %mm% to %m% for minutes
- LogCleanup: "Cleanup started" message is displayed as info not debug anymore
- Updated Readme to fit 3.1.0 and added changelog
- example file retentiondays changed from 14 -> 9999 to prevent accidential deletion
- Version and release date in main file
- Removed several lines with trailing whitespaces

### Bugfixes
- Only fallback timestamp is used, caused by false condition
- Custom entry types not working
- example importing wrong file; changed to psd1
- constructor only accepting int32 as path; changed from $this.LogFilePath-1 to $this.LogFilePath.Length-1
- SelectEntryType returning the input, and not the result